### PR TITLE
Add template options helper

### DIFF
--- a/documents/component.md
+++ b/documents/component.md
@@ -4,14 +4,14 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.gjs
+# {{hasOpts "!typescript" "!classBased"}}{{inputs.name.path}}.gjs
 
 ```gjs
 <template>{{"{{"}}yield{{"}}"}}</template>
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.gjs
+# {{hasOpts "!typescript" "classBased"}}{{inputs.name.path}}.gjs
 
 ```gjs
 import Component from "@glimmer/component";
@@ -22,7 +22,7 @@ export default class {{inputs.name.pascal}} extends Component {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.gts
+# {{hasOpts "typescript" "!classBased"}}{{inputs.name.path}}.gts
 
 ```gts
 import type { TOC } from '@ember/component/template-only';
@@ -41,7 +41,7 @@ export default {{inputs.name.pascal}};
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.gts
+# {{hasOpts "typescript" "classBased"}}{{inputs.name.path}}.gts
 
 ```gts
 import Component from "@glimmer/component";

--- a/documents/config.ts
+++ b/documents/config.ts
@@ -1,3 +1,59 @@
-export default {
+import type { Config } from "scaffdog";
+
+/**
+ * Given an array of strings, this function will return a tuple of two arrays:
+ * - The first array will contain all the strings that do not begin with a '!'.
+ * - The second array will contain all the strings that do begin with a '!',
+ *   with the '!' removed.
+ */
+function parseOptions(options: string[]): [string[], string[]] {
+  const positive: string[] = [];
+  const negative: string[] = [];
+
+  for (let i = 0; i < options.length; i++) {
+    if (options[i].startsWith("!")) {
+      negative.push(options[i].slice(1));
+    } else {
+      positive.push(options[i]);
+    }
+  }
+
+  return [positive, negative];
+}
+
+const config: Config = {
   files: ["*.md"],
+  helpers: [
+    (registry): void => {
+      /**
+       * This helper looks at `context.inputs` and `options` and returns either
+       * '' or '!' based on the values of the options in `context.inputs`.  If
+       * an option starts with a '!', it is considered a negative option and
+       * will be checked for falsy values. Otherwise, the option will be
+       * checked for truthy values.
+       *
+       * For example, if `context.inputs` is `{ foo: true, bar: false }`, then:
+       * - `{{hasOpts "foo"}}` will return '' because `foo` is truthy
+       * - `{{hasOpts "!foo"}}` will return '!' because `foo` is truthy
+       * - `{{hasOpts "bar"}}` will return '!' because `bar` is falsy
+       * - `{{hasOpts "!bar"}}` will return '' because `bar` is falsy
+       * - `{{hasOpts "foo" "!bar"}}` will return '' because `foo` is truthy
+       *      and `bar` is falsy
+       * - `{{hasOpts "foo" "bar"}}` will return '!' because `foo` is truthy
+       *      and `bar` is falsy
+       * - `{{hasOpts "!foo" "!bar"}}` will return '!' because `foo` is truthy
+       *      and `bar` is falsy
+       */
+      registry.set("hasOpts", (context, ...options) => {
+        const [positive, negative] = parseOptions(options);
+        const inputs = context.variables.get("inputs");
+
+        const allPositive = positive.every((opt) => inputs?.[opt]);
+        const noNegative = negative.every((opt) => !inputs?.[opt]);
+
+        return allPositive && noNegative ? "" : "!";
+      });
+    },
+  ],
 };
+export default config;

--- a/documents/helper.md
+++ b/documents/helper.md
@@ -4,7 +4,7 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.js
+# {{hasOpts "!typescript" "!classBased"}}{{inputs.name.path}}.js
 
 ```js
 import { helper } from "@ember/component/helper";
@@ -15,7 +15,7 @@ export default helper(function {{inputs.name.camel}}(positional, named) {
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.js
+# {{hasOpts "!typescript" "classBased"}}{{inputs.name.path}}.js
 
 ```js
 import Helper from "@ember/component/helper";
@@ -28,7 +28,7 @@ export default class {{inputs.name.pascal}} extends Helper {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.ts
+# {{hasOpts "typescript" "!classBased"}}{{inputs.name.path}}.ts
 
 ```ts
 import { helper } from "@ember/component/helper";
@@ -51,7 +51,7 @@ export default helper<{{inputs.signature}}>(function {{inputs.name.camel}}(posit
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.ts
+# {{hasOpts "typescript" "classBased"}}{{inputs.name.path}}.ts
 
 ```ts
 import Helper from "@ember/component/helper";

--- a/documents/modifier.md
+++ b/documents/modifier.md
@@ -4,7 +4,7 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.js
+# {{hasOpts "!typescript" "!classBased"}}{{inputs.name.path}}.js
 
 ```js
 import { modifier } from "ember-modifier";
@@ -13,7 +13,7 @@ export default modifier(function {{inputs.name.camel}}(element, positional, name
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.js
+# {{hasOpts "!typescript" "classBased"}}{{inputs.name.path}}.js
 
 ```js
 import Modifier from "ember-modifier";
@@ -24,7 +24,7 @@ export default class {{inputs.name.pascal}} extends Modifier {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.ts
+# {{hasOpts "typescript" "!classBased"}}{{inputs.name.path}}.ts
 
 ```ts
 import { modifier } from "ember-modifier";
@@ -41,7 +41,7 @@ export default modifier<{{inputs.signature}}>(function {{inputs.name.camel}}(ele
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.ts
+# {{hasOpts "typescript" "classBased"}}{{inputs.name.path}}.ts
 
 ```ts
 import Modifier from "ember-modifier";


### PR DESCRIPTION
This PR adds a small helper to Scaffdog to make writing templates slightly cleaner.

The `hasOpts` helper lets you tersely determine if a filename should be preceded by a "!" and thereby excluded from generation.  The goal is to eliminate the use of nested ternary operators and arguably make the template easier to understand.

So instead of this:

```
# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.js
```

you can write this:

```
# {{hasOpts "!typescript" "classBased"}}{{inputs.name.path}}.js
```

I was playing around with supporting some additional options and found that adding a third (or fourth) ternary expression to the filename prefix code was getting ugly.

Feel free to close and ignore if you don't think this is something worthwhile.

