### PR TITLE
Remove nested ternary operators in generator documents

### DIFF
--- a/documents/component.md
+++ b/documents/component.md
@@ -4,14 +4,14 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.gjs
+# {{!inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.gjs
 
 ```gjs
 <template>{{"{{"}}yield{{"}}"}}</template>
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.gjs
+# {{!inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.gjs
 
 ```gjs
 import Component from "@glimmer/component";
@@ -22,7 +22,7 @@ export default class {{inputs.name.pascal}} extends Component {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.gts
+# {{inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.gts
 
 ```gts
 import type { TOC } from '@ember/component/template-only';
@@ -41,7 +41,7 @@ export default {{inputs.name.pascal}};
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.gts
+# {{inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.gts
 
 ```gts
 import Component from "@glimmer/component";

--- a/documents/config.ts
+++ b/documents/config.ts
@@ -1,3 +1,7 @@
-export default {
+import type { Config } from "scaffdog";
+
+const config: Config = {
   files: ["*.md"],
 };
+
+export default config;

--- a/documents/helper.md
+++ b/documents/helper.md
@@ -4,7 +4,7 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.js
+# {{!inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.js
 
 ```js
 import { helper } from "@ember/component/helper";
@@ -15,7 +15,7 @@ export default helper(function {{inputs.name.camel}}(positional, named) {
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.js
+# {{!inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.js
 
 ```js
 import Helper from "@ember/component/helper";
@@ -28,7 +28,7 @@ export default class {{inputs.name.pascal}} extends Helper {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.ts
+# {{inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.ts
 
 ```ts
 import { helper } from "@ember/component/helper";
@@ -51,7 +51,7 @@ export default helper<{{inputs.signature}}>(function {{inputs.name.camel}}(posit
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.ts
+# {{inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.ts
 
 ```ts
 import Helper from "@ember/component/helper";

--- a/documents/modifier.md
+++ b/documents/modifier.md
@@ -4,7 +4,7 @@ root: "."
 output: "**/*"
 ---
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "!" : "")}}{{inputs.name.path}}.js
+# {{!inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.js
 
 ```js
 import { modifier } from "ember-modifier";
@@ -13,7 +13,7 @@ export default modifier(function {{inputs.name.camel}}(element, positional, name
 
 ```
 
-# {{inputs.typescript ? "!" : (inputs.classBased ? "" : "!")}}{{inputs.name.path}}.js
+# {{!inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.js
 
 ```js
 import Modifier from "ember-modifier";
@@ -24,7 +24,7 @@ export default class {{inputs.name.pascal}} extends Modifier {
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "!" : "") : "!"}}{{inputs.name.path}}.ts
+# {{inputs.typescript && !inputs.classBased ? "" : "!"}}{{inputs.name.path}}.ts
 
 ```ts
 import { modifier } from "ember-modifier";
@@ -41,7 +41,7 @@ export default modifier<{{inputs.signature}}>(function {{inputs.name.camel}}(ele
 
 ```
 
-# {{inputs.typescript ? (inputs.classBased ? "" : "!") : "!"}}{{inputs.name.path}}.ts
+# {{inputs.typescript && inputs.classBased ? "" : "!"}}{{inputs.name.path}}.ts
 
 ```ts
 import Modifier from "ember-modifier";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
       ignored: ["**/test/output/**"],
     },
   },
+  test: {
+    forceRerunTriggers: ["**/documents/**"],
+  },
 });


### PR DESCRIPTION
Valid feedback from @tcjr, that these are hard to read / reason about, and there's really no good reason to use them here.

Closes #42.